### PR TITLE
Basic Loadout Selection

### DIFF
--- a/three-fps/src/App.tsx
+++ b/three-fps/src/App.tsx
@@ -35,7 +35,9 @@ export default function App() {
 					<AvatarPage />
 				</Route>
 				<Route path="/loadout">
-					<LoadoutPage />
+					<Provider store={store} >
+						<LoadoutPage />
+					</Provider>
 				</Route>
 				<Route path="/start">
 					<Provider store={store} >

--- a/three-fps/src/Game/GameContainer.tsx
+++ b/three-fps/src/Game/GameContainer.tsx
@@ -7,7 +7,6 @@ import { useSelector } from "react-redux"
 import { RootState } from "./Reducers/GameStore"
 
 const destructibleComponents : any = {
-	"Player": Player,
 	"Cube": Cube,
 	"Zombie": Zombie
 }
@@ -27,12 +26,14 @@ function GameContainer() : ReactElement {
 		const data = destructibles[name]
 
 		const gameComponent = destructibleComponents[data.componentType]
-		gameChildren.push(React.createElement(gameComponent, data.props))
+		const destrucibleProps = {...data.props, "key": data.props["objectID"]}
+		gameChildren.push(React.createElement(gameComponent, destrucibleProps))
 	}
 
 	return (
 		<>
-			<Ground />
+			<Ground key="ground" />
+			<Player key="player" objectID={"player1"} position={[0, 1, 0]} />
 			{gameChildren}
 		</>
 	)

--- a/three-fps/src/Game/Items/useRaycaster.ts
+++ b/three-fps/src/Game/Items/useRaycaster.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react"
 import { Raycaster } from "three"
 import { useDispatch } from "react-redux"
 import { destructibleActions } from "../Reducers/destructibleSlice"
+import { playerActions } from "../Reducers/playerSlice"
 
 const raycaster = new Raycaster()
 
@@ -31,8 +32,7 @@ export const useGun = (damage: number, slot: number, ammo: number, parentID: str
 				let doesIntersect = false
 				let intersectID = null
 
-				dispatch(destructibleActions.decrementAmmo({
-					objectID: parentID,
+				dispatch(playerActions.decrementAmmo({
 					ammo: 1,
 					slot: slot
 				}))

--- a/three-fps/src/Game/Player/Player.tsx
+++ b/three-fps/src/Game/Player/Player.tsx
@@ -12,8 +12,16 @@ import { PlayerController } from "./PlayerController"
  * @returns A PlayerController, which handles the player's mesh and movements
  */
 export function Player(props : any) : ReactElement | null {
-	const health = useSelector((state : RootState) => state.destructibles.destructibles[props.objectID].health)
-	const ammo = useSelector((state : RootState) => state.destructibles.destructibles[props.objectID].ammo)
+	const health = useSelector((state : RootState) => state.player.health)
+	const ammo = useSelector((state : RootState) => {
+		return [
+			state.player.slots[0].ammo,
+			state.player.slots[1].ammo,
+			state.player.slots[2].ammo,
+			state.player.slots[3].ammo,
+		]
+	})
+	const configs = useSelector((state: RootState) => state.player.slots)
 	console.log(health)
 
 	if (health > 0) {
@@ -22,24 +30,7 @@ export function Player(props : any) : ReactElement | null {
 				objectID={props.objectID}
 				health={health}
 				ammo={ammo}
-				configs={[
-					{
-						damage: 20,
-						assetID: "./lasgun.gltf",
-					},
-					{
-						damage: 10,
-						assetID: "./lasgun2.gltf",
-					},
-					{
-						damage: 40,
-						assetID: "./lasgun3.gltf",
-					},
-					{
-						damage: 25,
-						assetID: "./lasgun4.gltf",
-					}
-				]}
+				configs={configs}
 				parentID={props.objectID}
 				{...props}
 			/>

--- a/three-fps/src/Game/Reducers/GameStore.ts
+++ b/three-fps/src/Game/Reducers/GameStore.ts
@@ -1,5 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit"
 import destructibleReducer from "./destructibleSlice"
+import playerReducer from "./playerSlice"
 
 /**
  * Object store. Holds object metadata like health and ammo.
@@ -7,7 +8,8 @@ import destructibleReducer from "./destructibleSlice"
  */
 const store = configureStore({
 	reducer: {
-		destructibles: destructibleReducer
+		destructibles: destructibleReducer,
+		player: playerReducer,
 	}
 })
 

--- a/three-fps/src/Game/Reducers/GameStore.ts
+++ b/three-fps/src/Game/Reducers/GameStore.ts
@@ -1,6 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit"
 import destructibleReducer from "./destructibleSlice"
 import playerReducer from "./playerSlice"
+import availableItemsReducer from "./availableItemsSlice"
 
 /**
  * Object store. Holds object metadata like health and ammo.
@@ -10,6 +11,7 @@ const store = configureStore({
 	reducer: {
 		destructibles: destructibleReducer,
 		player: playerReducer,
+		availableItems: availableItemsReducer,
 	}
 })
 

--- a/three-fps/src/Game/Reducers/availableItemsSlice.ts
+++ b/three-fps/src/Game/Reducers/availableItemsSlice.ts
@@ -1,0 +1,56 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+export type AvailableItem = {
+	damage: number,
+	assetID: string,
+	ammo: number,
+	name: string,
+}
+
+type InitialState = {
+	items: Array<AvailableItem>,
+}
+
+const initialState : InitialState = {
+	items: [
+		{
+			damage: 20,
+			assetID: "./lasgun.gltf",
+			ammo: 40,
+			name: "Lasgun",
+		},
+		{
+			damage: 10,
+			assetID: "./lasgun2.gltf",
+			ammo: 30,
+			name: "Hello World",
+		},
+		{
+			damage: 40,
+			assetID: "./lasgun3.gltf",
+			ammo: 25,
+			name: "if elseif",
+		},
+		{
+			damage: 25,
+			assetID: "./lasgun4.gltf",
+			ammo: 3,
+			name: "snakebite"
+		}
+	]
+}
+
+export const availableItemsSlice = createSlice({
+	name: "availableItems",
+	initialState,
+	reducers: {
+		// Add destructibles to the global store
+		addItems: (state, action) => {
+			const items : Array<AvailableItem> = action.payload.items
+			items.forEach((item) => state.items.push(item))
+		},
+	}
+})
+
+export const availableItemsActions = availableItemsSlice.actions
+export default availableItemsSlice.reducer

--- a/three-fps/src/Game/Reducers/destructibleSlice.ts
+++ b/three-fps/src/Game/Reducers/destructibleSlice.ts
@@ -1,17 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit"
 
 const initialState : any = {
-	destructibles: {
-		player1: {
-			componentType: "Player",
-			props: {
-				position: [0, 1, 0],
-				objectID: "player1",
-			},
-			health: 100,
-			ammo: [40, 30, 25, 3],
-		},
-	},
+	destructibles: {},
 }
 
 /**
@@ -35,14 +25,6 @@ export const destructibleSlice = createSlice({
 		// Increment health of a destructible
 		incrementHealth: (state, action) => {
 			state.destructibles[action.payload.objectID].health += action.payload.healAmount
-		},
-		// Decrement ammo. Not all objects handle ammo
-		decrementAmmo: (state, action) => {
-			state.destructibles[action.payload.objectID].ammo[action.payload.slot] -= action.payload.ammo
-		},
-		// Increment ammo. Not all objects handle ammo
-		incrementAmmo: (state, action) => {
-			state.destructibles[action.payload.objectID].ammo[action.payload.slot] += action.payload.ammo
 		},
 	}
 })

--- a/three-fps/src/Game/Reducers/playerSlice.ts
+++ b/three-fps/src/Game/Reducers/playerSlice.ts
@@ -1,0 +1,57 @@
+import { createSlice } from "@reduxjs/toolkit"
+
+const initialState : any = {
+	health: 100,
+	slots: [
+		{
+			damage: 20,
+			assetID: "./lasgun.gltf",
+			ammo: 40,
+		},
+		{
+			damage: 10,
+			assetID: "./lasgun2.gltf",
+			ammo: 30,
+		},
+		{
+			damage: 40,
+			assetID: "./lasgun3.gltf",
+			ammo: 25,
+		},
+		{
+			damage: 25,
+			assetID: "./lasgun4.gltf",
+			ammo: 3,
+		}
+	]
+
+}
+
+export const playerSlice = createSlice({
+	name: "player",
+	// TODO: Handle state initialization for more destructibles with addDestructibles
+	initialState,
+	reducers: {
+		// Add destructibles to the global store
+		updateSlot: (state, action) => {
+			state[action.payload.slot] = action.payload.item
+		},
+		// Decrement ammo
+		decrementAmmo: (state, action) => {
+			state.slots[action.payload.slot].ammo -= action.payload.ammo
+		},
+		// Increment ammo
+		incrementAmmo: (state, action) => {
+			state.slots[action.payload.slot].ammo += action.payload.ammo
+		},
+		decrementHealth: (state, action) => {
+			state.health -= action.payload.damageAmount
+		},
+		incrementHealth: (state, action) => {
+			state.health += action.payload.healAmount
+		}
+	}
+})
+
+export const playerActions = playerSlice.actions
+export default playerSlice.reducer

--- a/three-fps/src/Game/Reducers/playerSlice.ts
+++ b/three-fps/src/Game/Reducers/playerSlice.ts
@@ -1,27 +1,37 @@
 import { createSlice } from "@reduxjs/toolkit"
+import { AvailableItem } from "./availableItemsSlice"
 
-const initialState : any = {
+type InitialState = {
+	health: number,
+	slots: Array<AvailableItem>,
+}
+
+const initialState : InitialState = {
 	health: 100,
 	slots: [
 		{
 			damage: 20,
 			assetID: "./lasgun.gltf",
 			ammo: 40,
+			name: "Lasgun",
 		},
 		{
 			damage: 10,
 			assetID: "./lasgun2.gltf",
 			ammo: 30,
+			name: "Hello World",
 		},
 		{
 			damage: 40,
 			assetID: "./lasgun3.gltf",
 			ammo: 25,
+			name: "if elseif",
 		},
 		{
 			damage: 25,
 			assetID: "./lasgun4.gltf",
 			ammo: 3,
+			name: "snakebite"
 		}
 	]
 

--- a/three-fps/src/Game/Reducers/playerSlice.ts
+++ b/three-fps/src/Game/Reducers/playerSlice.ts
@@ -34,7 +34,7 @@ export const playerSlice = createSlice({
 	reducers: {
 		// Add destructibles to the global store
 		updateSlot: (state, action) => {
-			state[action.payload.slot] = action.payload.item
+			state.slots[action.payload.slot] = action.payload.item
 		},
 		// Decrement ammo
 		decrementAmmo: (state, action) => {

--- a/three-fps/src/Game/Zombies/ZombieMesh.tsx
+++ b/three-fps/src/Game/Zombies/ZombieMesh.tsx
@@ -4,7 +4,7 @@ import { useSphere } from "@react-three/cannon"
 import { useFrame } from "@react-three/fiber"
 import { getPosition } from "../Reducers/playerPositionReducer"
 import { useDispatch } from "react-redux"
-import { destructibleActions } from "../Reducers/destructibleSlice"
+import { playerActions } from "../Reducers/playerSlice"
 
 const direction = new THREE.Vector3()
 const speed = new THREE.Vector3()
@@ -28,8 +28,7 @@ export const ZombieMesh = (props : any) : ReactElement => {
 		const intersectData = e.body.userData
 		if (intersectData.type === "Player"){
 			console.log(intersectData.id)
-			dispatch(destructibleActions.decrementHealth({
-				objectID: intersectData.id,
+			dispatch(playerActions.decrementHealth({
 				damageAmount: props.damage,
 			}))
 		}

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutDisplayItem.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutDisplayItem.tsx
@@ -1,0 +1,48 @@
+import { ReactElement } from "react"
+import { Canvas } from "@react-three/fiber"
+
+import React, { useRef, Suspense } from "react"
+import { Environment, Html, OrbitControls, useGLTF, useProgress } from "@react-three/drei"
+import { GLTF } from "three-stdlib/loaders/GLTFLoader"
+
+type GLTFResult = GLTF & {
+  nodes: {
+    Cube: THREE.Mesh
+  }
+  materials: {
+    Material: THREE.MeshStandardMaterial
+  }
+}
+
+type LoadoutDisplayItemProps = {
+	assetID: string
+}
+
+
+function Loader() {
+	const { active, progress, errors, item, loaded, total } = useProgress()
+	return <Html center>{progress} % loaded</Html>
+}
+
+export default function LoadoutDisplayItem(props : LoadoutDisplayItemProps) : ReactElement {
+	const group = useRef()
+	const { nodes, materials } = useGLTF(props.assetID, true) as GLTFResult
+
+	return (
+		<Canvas>
+			<Suspense fallback={<Loader />}>
+				<group ref={group} {...props} dispose={null}>
+					<mesh
+						castShadow
+						receiveShadow
+						geometry={nodes.Cube.geometry}
+						material={materials.Material}
+						scale={[1, 1, 1]}
+					/>
+				</group>
+				<OrbitControls />
+				<Environment preset="sunset" background />
+			</Suspense>
+		</Canvas>
+	)
+}

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
@@ -4,14 +4,15 @@ export type LoadoutListItemProps = {
 	name: string,
 	maxAmmo: number,
 	damage: number,
-	onClick: () => null,
+	assetID: string,
+	onClick: (assetIDToDisplay: string) => void,
 }
 
 export default function LoadoutListItem(props: LoadoutListItemProps) : ReactElement {
 
 	return (
 		<div>
-			<button onClick={props.onClick} >
+			<button onClick={() => props.onClick(props.assetID)} >
 				<h1>{props.name}</h1>
 				<h2>Damage: {props.damage}</h2>
 				<h2>Max Ammo: {props.maxAmmo}</h2>

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
@@ -1,0 +1,21 @@
+import { ReactElement } from "react"
+
+export type LoadoutListItemProps = {
+	name: string,
+	maxAmmo: number,
+	damage: number,
+	onClick: () => null,
+}
+
+export default function LoadoutListItem(props: LoadoutListItemProps) : ReactElement {
+
+	return (
+		<div>
+			<button onClick={props.onClick} >
+				<h1>{props.name}</h1>
+				<h2>Damage: {props.damage}</h2>
+				<h2>Max Ammo: {props.maxAmmo}</h2>
+			</button>
+		</div>
+	)
+}

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
@@ -10,10 +10,10 @@ export default function LoadoutListItem(props: LoadoutListItemProps) : ReactElem
 
 	return (
 		<div>
-			<button onClick={() => props.onClick(props.item)} >
-				<h1>{props.item.name}</h1>
-				<h2>Damage: {props.item.damage}</h2>
-				<h2>Max Ammo: {props.item.ammo}</h2>
+			<button className="button2" onClick={() => props.onClick(props.item)} >
+				<h2>{props.item.name}</h2>
+				<p>Damage: {props.item.damage}</p>
+				<p>Max Ammo: {props.item.ammo}</p>
 			</button>
 		</div>
 	)

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutListItem.tsx
@@ -1,21 +1,19 @@
 import { ReactElement } from "react"
+import { AvailableItem } from "../../Game/Reducers/availableItemsSlice"
 
 export type LoadoutListItemProps = {
-	name: string,
-	maxAmmo: number,
-	damage: number,
-	assetID: string,
-	onClick: (assetIDToDisplay: string) => void,
+	item: AvailableItem
+	onClick: (item: AvailableItem) => void,
 }
 
 export default function LoadoutListItem(props: LoadoutListItemProps) : ReactElement {
 
 	return (
 		<div>
-			<button onClick={() => props.onClick(props.assetID)} >
-				<h1>{props.name}</h1>
-				<h2>Damage: {props.damage}</h2>
-				<h2>Max Ammo: {props.maxAmmo}</h2>
+			<button onClick={() => props.onClick(props.item)} >
+				<h1>{props.item.name}</h1>
+				<h2>Damage: {props.item.damage}</h2>
+				<h2>Max Ammo: {props.item.ammo}</h2>
 			</button>
 		</div>
 	)

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutPage.css
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutPage.css
@@ -1,5 +1,28 @@
 #items-list {
 	overflow-y: scroll;
-	max-height: 80%;
-	max-width: 20%;
+	height: 70vh;
+	width: 20%;
+	float: left;
+}
+
+#item-display {
+	float: right;
+	width: 80%;
+	height: 70vh;
+}
+
+#loadout-wrapper {
+	height: 70%;
+}
+
+#loadout-row {
+	display: table;
+	width: 100%;
+	height: 30vh;
+	border-spacing: 10px;
+}
+
+.loadout-slot {
+	display: table-cell;
+	background-color: crimson;
 }

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutPage.css
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutPage.css
@@ -1,0 +1,5 @@
+#items-list {
+	overflow-y: scroll;
+	max-height: 80%;
+	max-width: 20%;
+}

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutPage.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutPage.tsx
@@ -1,14 +1,22 @@
 import "./LoadoutPage.css"
-import { ReactElement } from "react"
+import { ReactElement, Suspense } from "react"
 import { useSelector } from "react-redux"
 import { AvailableItem } from "../../Game/Reducers/availableItemsSlice"
 import { RootState } from "../../Game/Reducers/GameStore"
 import LoadoutListItem from "./LoadoutListItem"
+import LoadoutDisplayItem from "./LoadoutDisplayItem"
+import { useState } from "react"
 
 export default function LoadoutPage(props: any) : ReactElement {
 	const availableItems : Array<AvailableItem> = useSelector((state: RootState) => state.availableItems.items)
 
 	const loadoutItemsList : Array<ReactElement> = []
+
+	const [assetID, setAssetID] = useState(availableItems[0].assetID)
+
+	const onClickDisplayAsset = (assetIDToDisplay : string) => {
+		setAssetID(assetIDToDisplay)
+	}
 
 	availableItems.forEach((item) => {
 		loadoutItemsList.push(
@@ -16,7 +24,8 @@ export default function LoadoutPage(props: any) : ReactElement {
 				name={item.name}
 				maxAmmo={item.ammo}
 				damage={item.damage}
-				onClick={() => null}
+				assetID={item.assetID}
+				onClick={onClickDisplayAsset}
 			/>
 		)
 	})
@@ -24,11 +33,21 @@ export default function LoadoutPage(props: any) : ReactElement {
 	return (
 		<div>
 			<h1>Loadout</h1>
-			<div id="items-list">
-				{loadoutItemsList}
+			<div id="loadout-wrapper">
+				<div id="items-list">
+					{loadoutItemsList}
+				</div>
+				<div id="item-display">
+					<Suspense fallback={null} >
+						<LoadoutDisplayItem assetID={assetID} />
+					</Suspense>
+				</div>
 			</div>
-			<div id="item-display">
-
+			<div id="loadout-row">
+				<div className="loadout-slot">Slot 1</div>
+				<div className="loadout-slot">Slot 2</div>
+				<div className="loadout-slot">Slot 3</div>
+				<div className="loadout-slot">Slot 4</div>
 			</div>
 		</div>
 	)

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutPage.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutPage.tsx
@@ -1,30 +1,41 @@
 import "./LoadoutPage.css"
 import { ReactElement, Suspense } from "react"
-import { useSelector } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
 import { AvailableItem } from "../../Game/Reducers/availableItemsSlice"
 import { RootState } from "../../Game/Reducers/GameStore"
 import LoadoutListItem from "./LoadoutListItem"
 import LoadoutDisplayItem from "./LoadoutDisplayItem"
 import { useState } from "react"
+import LoadoutSlot from "./LoadoutSlot"
+import { playerActions } from "../../Game/Reducers/playerSlice"
 
 export default function LoadoutPage(props: any) : ReactElement {
 	const availableItems : Array<AvailableItem> = useSelector((state: RootState) => state.availableItems.items)
+	const slotItems: Array<AvailableItem> = useSelector((state: RootState) => state.player.slots)
+	const dispatch = useDispatch()
 
 	const loadoutItemsList : Array<ReactElement> = []
 
 	const [assetID, setAssetID] = useState(availableItems[0].assetID)
+	const [selectedSlot, setSelectedSlot] = useState(0)
 
-	const onClickDisplayAsset = (assetIDToDisplay : string) => {
+	const onClickDisplayAsset = (item : AvailableItem) => {
+		setAssetID(item.assetID)
+		dispatch(playerActions.updateSlot({
+			slot: selectedSlot,
+			item: item,
+		}))
+	}
+
+	const onClickSlot = (assetIDToDisplay : string, slotNumber : number) => {
 		setAssetID(assetIDToDisplay)
+		setSelectedSlot(slotNumber)
 	}
 
 	availableItems.forEach((item) => {
 		loadoutItemsList.push(
 			<LoadoutListItem
-				name={item.name}
-				maxAmmo={item.ammo}
-				damage={item.damage}
-				assetID={item.assetID}
+				item={item}
 				onClick={onClickDisplayAsset}
 			/>
 		)
@@ -44,10 +55,10 @@ export default function LoadoutPage(props: any) : ReactElement {
 				</div>
 			</div>
 			<div id="loadout-row">
-				<div className="loadout-slot">Slot 1</div>
-				<div className="loadout-slot">Slot 2</div>
-				<div className="loadout-slot">Slot 3</div>
-				<div className="loadout-slot">Slot 4</div>
+				<LoadoutSlot item={slotItems[0]} slotNumber={0} onClick={onClickSlot}/>
+				<LoadoutSlot item={slotItems[1]} slotNumber={1} onClick={onClickSlot}/>
+				<LoadoutSlot item={slotItems[2]} slotNumber={2} onClick={onClickSlot}/>
+				<LoadoutSlot item={slotItems[3]} slotNumber={3} onClick={onClickSlot}/>
 			</div>
 		</div>
 	)

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutPage.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutPage.tsx
@@ -1,9 +1,35 @@
+import "./LoadoutPage.css"
 import { ReactElement } from "react"
+import { useSelector } from "react-redux"
+import { AvailableItem } from "../../Game/Reducers/availableItemsSlice"
+import { RootState } from "../../Game/Reducers/GameStore"
+import LoadoutListItem from "./LoadoutListItem"
 
 export default function LoadoutPage(props: any) : ReactElement {
+	const availableItems : Array<AvailableItem> = useSelector((state: RootState) => state.availableItems.items)
+
+	const loadoutItemsList : Array<ReactElement> = []
+
+	availableItems.forEach((item) => {
+		loadoutItemsList.push(
+			<LoadoutListItem
+				name={item.name}
+				maxAmmo={item.ammo}
+				damage={item.damage}
+				onClick={() => null}
+			/>
+		)
+	})
+
 	return (
 		<div>
 			<h1>Loadout</h1>
+			<div id="items-list">
+				{loadoutItemsList}
+			</div>
+			<div id="item-display">
+
+			</div>
 		</div>
 	)
 }

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutSlot.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutSlot.tsx
@@ -12,11 +12,11 @@ export default function LoadoutSlot(props: LoadoutSlotProps) : ReactElement {
 
 	return (
 		<div className="loadout-slot">
-			<button onClick={() => props.onClick(props.item.assetID, props.slotNumber)} >
-				<h1>Slot: {props.slotNumber + 1}</h1>
-				<h2>{props.item.name}</h2>
-				<h2>Max Ammo: {props.item.ammo}</h2>
-				<h2>Damage: {props.item.damage}</h2>
+			<button className="button1" onClick={() => props.onClick(props.item.assetID, props.slotNumber)} >
+				<p>Slot {props.slotNumber + 1}</p>
+				<p>{props.item.name}</p>
+				<p>Max Ammo: {props.item.ammo}</p>
+				<p>Damage: {props.item.damage}</p>
 			</button>
 		</div>
 	)

--- a/three-fps/src/Webpage/LoadoutPage/LoadoutSlot.tsx
+++ b/three-fps/src/Webpage/LoadoutPage/LoadoutSlot.tsx
@@ -1,0 +1,23 @@
+import { ReactElement } from "react"
+import { AvailableItem } from "../../Game/Reducers/availableItemsSlice"
+import "./LoadoutPage.css"
+
+export type LoadoutSlotProps = {
+	slotNumber: number,
+	item: AvailableItem,
+	onClick: (assetIDToDisplay: string, slotNumber: number) => void,
+}
+
+export default function LoadoutSlot(props: LoadoutSlotProps) : ReactElement {
+
+	return (
+		<div className="loadout-slot">
+			<button onClick={() => props.onClick(props.item.assetID, props.slotNumber)} >
+				<h1>Slot: {props.slotNumber + 1}</h1>
+				<h2>{props.item.name}</h2>
+				<h2>Max Ammo: {props.item.ammo}</h2>
+				<h2>Damage: {props.item.damage}</h2>
+			</button>
+		</div>
+	)
+}

--- a/three-fps/src/Webpage/StartPage/StartPage.tsx
+++ b/three-fps/src/Webpage/StartPage/StartPage.tsx
@@ -4,15 +4,6 @@ import { Link } from "react-router-dom"
 import { destructibleActions } from "../../Game/Reducers/destructibleSlice"
 
 const defaultConfig = {
-	player1: {
-		componentType: "Player",
-		props: {
-			position: [0, 1, 0],
-			objectID: "player1",
-		},
-		health: 100,
-		ammo: [40, 30, 25, 3],
-	},
 	object2: {
 		componentType: "Cube",
 		props: {


### PR DESCRIPTION
Closes #39 

## Changes
- Removes the Player from the list of Destructibles and adds it to its own redux slice
- Loadouts can be selected from the loadout screen from a list of available items